### PR TITLE
Updating Demo to consume Equipment API Façade

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -1,12 +1,12 @@
 angular.module('fuseTestApp')
   .factory('Config', () => {
     const FUSE_TRACKERS_URL = window.FUSE_TRACKERS_URL;
-    const FUSE_EM_URL = window.FUSE_EM_URL;
+    const FUSE_EQUIPMENT_API_URL = window.FUSE_EQUIPMENT_API_URL;
     const BEARER_TOKEN = window.BEARER_TOKEN;
 
     return {
       FUSE_TRACKERS_URL,
-      FUSE_EM_URL,
+      FUSE_EQUIPMENT_API_URL,
       BEARER_TOKEN
     };
   });

--- a/app/scripts/controllers/equipment.js
+++ b/app/scripts/controllers/equipment.js
@@ -5,22 +5,8 @@
  * # EquipmentctrlCtrl
  * Controller of the fuseTestApp
  */
-
-const getEngineHours = (response) => {
-  const value = response
-    .meta
-    .aggregations
-    .equip_agg[0]
-    .spn_ag[0]
-    .spn_latest_ag[0]
-    .value;
-
-  return parseInt(value / 3600, 10);
-};
-
 function EquipmentController($routeParams, $scope, ApiService) {
   const equipmentId = $routeParams.id;
-
   $scope.map = {
     center: {
       latitude: 45,
@@ -31,29 +17,8 @@ function EquipmentController($routeParams, $scope, ApiService) {
   };
 
   ApiService.getEquipmentById(equipmentId).then((response) => {
-    $scope.equipment = response.equipment[0];
-    $scope.brand = response.linked.brands[0];
-    $scope.model = response.linked.models[0];
-    $scope.dealer = response.linked.dealers[0];
+    $scope.equipment = response.data;
   });
-
-  ApiService.getEngineHours()
-    .then(getEngineHours)
-    .then((engineHours) => { $scope.engineHours = engineHours; });
-
-  const watchExpression = () => {
-    return $scope.map.bounds;
-  };
-
-  const listener = () => {
-    ApiService.getTrackingPointsByEquipmentId(equipmentId).then((response) => {
-      if (response.trackingPoints.length > 0) {
-        $scope.trackingPoint = response.trackingPoints[0];
-      }
-    });
-  };
-
-  $scope.$watch(watchExpression, listener, true);
 }
 angular.module('fuseTestApp')
   .controller('EquipmentCtrl', EquipmentController);

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -5,67 +5,12 @@
  * # MainCtrl
  * Controller of the fuseTestApp
  */
-
-const attachDealersToEquipments = (equipments, dealers) => {
-  const dealerNames = {};
-  dealers.forEach((dealer) => {
-    dealerNames[dealer.id] = dealer.name;
-  });
-
-  equipments.forEach((equipment, index) => {
-    equipments[index].owner_name = null;
-    equipments[index].dealer_name = dealerNames[equipment.links.dealer];
-  });
-
-  return equipments;
-};
-
-const indexById = (entities) => {
-  const hash = {};
-
-  entities.forEach((entity) => {
-    hash[entity.id] = entity;
-  });
-
-  return hash;
-};
-
-const updateEquipmentEngineHours = (response, equipments) => {
-  const trackingPoints = indexById(response.linked.trackingPoints);
-  const duties = indexById(response.linked.duties);
-
-  const states = {};
-  const engineHours = {};
-  const aggs = response.meta.aggregations.equip_agg;
-  aggs.forEach((agg) => {
-    const latest = agg.spn_ag[0].spn_latest_ag;
-    const trackingPoint = trackingPoints[latest[0].links.trackingPoint];
-    const duty = duties[trackingPoint.links.duty];
-
-    engineHours[agg.key] = parseInt(latest[0].value / 3600, 10);
-    states[agg.key] = duty.status;
-  });
-
-  equipments.forEach((equipment, index) => {
-    equipments[index].engineHours = engineHours[equipment.id];
-    equipments[index].status = states[equipment.id];
-  });
-
-  return equipments;
-};
-
 function MainController(ApiService, $scope) {
   ApiService.getEquipments()
     .then((response) => {
-      const equipments = response.equipment;
-      const dealers = response.linked.dealers;
-      attachDealersToEquipments(equipments, dealers);
-      return equipments;
+      return response;
     }).then((equipments) => {
-      return ApiService.getEngineHours()
-        .then((response) => updateEquipmentEngineHours(response, equipments));
-    }).then((equipments) => {
-      $scope.equipments = equipments;
+      $scope.equipments = equipments.data;
     });
 }
 angular.module('fuseTestApp')

--- a/app/scripts/services/apiservice.js
+++ b/app/scripts/services/apiservice.js
@@ -11,9 +11,7 @@ function ApiService(Config, $http) {
   const getEquipments = () => {
     const request = $http({
       method: 'GET',
-      url: `${Config.FUSE_TRACKERS_URL}/equipment?` +
-        'include=model,owner,dealer,tracker,model.equipmentType,' +
-        'model.series,model.series.brand'
+      url: `${Config.FUSE_EQUIPMENT_API_URL}/equipments`
     }).then((response) => {
       return response.data;
     });
@@ -23,46 +21,7 @@ function ApiService(Config, $http) {
   const getEquipmentById = (id) => {
     const request = $http({
       method: 'GET',
-      url: `${Config.FUSE_TRACKERS_URL}/equipment/${id}?` +
-        'include=model,owner,tracker,dealer,model.equipmentType,' +
-        'model.series,model.series.brand'
-    }).then((response) => {
-      return response.data;
-    });
-    return request;
-  };
-
-  const getEngineHours = () => {
-    const request = $http({
-      method: 'GET',
-      url: `${Config.FUSE_TRACKERS_URL}/trackingData/search?` +
-        'include=trackingPoint%2CtrackingPoint.duty&' +
-        'links.canVariable.name=ENGINE_HOURS&' +
-        'aggregations=equip_agg&' +
-        'equip_agg.property=links.trackingPoint.equipment.id&' +
-        'equip_agg.aggregations=spn_ag%2Ctp_latest_ag&' +
-        'spn_ag.property=links.canVariable.name&' +
-        'spn_ag.aggregations=spn_latest_ag&' +
-        'spn_latest_ag.type=top_hits&' +
-        'spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&' +
-        'spn_latest_ag.limit=1&' +
-        'spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&' +
-        'tp_latest_ag.type=top_hits&' +
-        'tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&' +
-        'tp_latest_ag.limit=1&' +
-        'tp_latest_ag.fields=links.trackingPoint&' +
-        'tp_latest_ag.include=trackingPoint'
-    }).then((response) => {
-      return response.data;
-    });
-    return request;
-  };
-
-  const getTrackingPointsByEquipmentId = (equipmentId) => {
-    const request = $http({
-      method: 'GET',
-      url: `${Config.FUSE_TRACKERS_URL}/trackingPoints?` +
-        `include=duty&limit=5000&links.equipment=${equipmentId}`
+      url: `${Config.FUSE_EQUIPMENT_API_URL}/equipments/${id}?`
     }).then((response) => {
       return response.data;
     });
@@ -71,9 +30,7 @@ function ApiService(Config, $http) {
 
   return {
     getEquipments,
-    getEngineHours,
-    getEquipmentById,
-    getTrackingPointsByEquipmentId
+    getEquipmentById
   };
 }
 

--- a/app/views/equipment.html
+++ b/app/views/equipment.html
@@ -12,25 +12,25 @@
 
       <dl class="dl-horizontal">
         <dt>Model</dt>
-        <dd>{{brand.name}} {{model.name}}</dd>
+        <dd>{{ equipment.relationships.model.data.id }}</dd>
 
         <dt>Id</dt>
-        <dd>{{equipment.identificationNumber}}</dd>
+        <dd>{{ equipment.attributes.identificationNumber }}</dd>
 
         <dt>Description</dt>
-        <dd>{{equipment.description}}</dd>
+        <dd>{{ equipment.attributes.description }}</dd>
 
         <dt>Service level</dt>
-        <dd>{{equipment.serviceLevel}}</dd>
+        <dd>{{ equipment.attributes.serviceLevel }}</dd>
 
         <dt>Owner</dt>
         <dd>N/A</dd>
 
         <dt>Dealer</dt>
-        <dd>{{dealer.name}}</dd>
+        <dd>{{ equipment.relationships.dealer.data.id }}</dd>
 
         <dt>Engine hours</dt>
-        <dd>{{engineHours}} hours</dd>
+        <dd>{{ equipment.attributes.trackingData.ENGINE_HOURS }} hours</dd>
       </dl>
     </div>
   </div>
@@ -44,7 +44,7 @@
     <div>
       <dl class="dl-horizontal">
         <dt>Coordinate</dt>
-        <dd>{{trackingPoint.location.coordinates}}</dd>
+        <dd>{{ equipment.attributes.trackingPoint.location.coordinates }}</dd>
       </div>
     </div>
   </div>

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -14,14 +14,14 @@
       </thead>
       <tbody>
         <tr ng-repeat="equipment in equipments">
-          <td><a href="#/equipment/{{equipment.id}}">{{equipment.description}}</a> <br/>
-            {{equipment.identificationNumber}}
+          <td><a href="#/equipment/{{ equipment.id }}">{{ equipment.attributes.description }}</a> <br/>
+            {{ equipment.attributes.identificationNumber }}
           </td>
-          <td>{{equipment.serviceLevel}}</td>
-          <td>{{equipment.engineHours}}</td>
-          <td>{{equipment.status}}</td>
+          <td>{{ equipment.attributes.serviceLevel }}</td>
+          <td>{{ equipment.attributes.trackingData.ENGINE_HOURS }}</td>
+          <td>{{ equipment.attributes.status }}</td>
           <td>N/A</td>
-          <td>{{equipment.dealer_name}}</td>
+          <td>{{ equipment.relationships.dealer.data.id }}</td>
         </tr>
       </tbody>
     </table>

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 module.exports = {
   PORT: process.env.PORT || '8000',
   FUSE_TRACKERS_URL: process.env.FUSE_TRACKERS_URL || 'https://agco-fuse-trackers-sandbox.herokuapp.com',
-  FUSE_EM_URL: process.env.FUSE_EM_URL || 'http://fuse-em-api-dev.herokuapp.com',
+  FUSE_EQUIPMENT_API_URL: process.env.EQUIPMENT_API_URL || 'https://fuse-equipment-api.herokuapp.com',
   OPENAM_USERNAME: process.env.OPENAM_USERNAME,
   OPENAM_PASSWORD: process.env.OPENAM_PASSWORD,
   OPENAM_URL: process.env.OPENAM_URL || 'https://aaat.agcocorp.com/auth/oauth2/access_token',

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const authenticateAsDealer = () => {
 const renderPage = (token, response) => {
   response.render('index', {
     FUSE_TRACKERS_URL: config.FUSE_TRACKERS_URL,
-    FUSE_EM_URL: config.FUSE_EM_URL,
+    FUSE_EQUIPMENT_API_URL: config.FUSE_EQUIPMENT_API_URL,
     BEARER_TOKEN: token
   });
 };

--- a/views/layouts/index.html
+++ b/views/layouts/index.html
@@ -23,8 +23,8 @@
     </div>
 
      <script>
-       window.FUSE_EM_URL = '{{FUSE_EM_URL}}';
        window.FUSE_TRACKERS_URL = '{{FUSE_TRACKERS_URL}}';
+       window.FUSE_EQUIPMENT_API_URL = '{{FUSE_EQUIPMENT_API_URL}}';
        window.BEARER_TOKEN = '{{BEARER_TOKEN}}';
     </script>
 


### PR DESCRIPTION
One of the goals for building the Equipment API Façade was to make it
easier retrieving equipment information from it than it is from Telemetry API.

This commit shows how much code we got rid by adopting it.